### PR TITLE
fix: Fix SupersetClient.postForm calls

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/connection/SupersetClientClass.ts
+++ b/superset-frontend/packages/superset-ui-core/src/connection/SupersetClientClass.ts
@@ -259,7 +259,7 @@ export default class SupersetClientClass {
 
   getUrl({
     host: inputHost,
-    endpoint,
+    endpoint = '',
     url,
   }: {
     endpoint?: string;

--- a/superset-frontend/packages/superset-ui-core/src/connection/SupersetClientClass.ts
+++ b/superset-frontend/packages/superset-ui-core/src/connection/SupersetClientClass.ts
@@ -27,6 +27,7 @@ import {
   Headers,
   Host,
   Mode,
+  PostFormConfig,
   Protocol,
   RequestConfig,
   ParseMethod,
@@ -115,19 +116,18 @@ export default class SupersetClientClass {
     return this.getCSRFToken();
   }
 
-  async postForm(
-    endpoint: string,
-    payload: Record<string, any>,
-    target = '_blank',
-  ) {
-    if (endpoint) {
+  async postForm(postFormConfig: PostFormConfig) {
+    if (postFormConfig.endpoint || postFormConfig.url) {
       await this.ensureAuth();
       const hiddenForm = document.createElement('form');
-      hiddenForm.action = this.getUrl({ endpoint });
+      hiddenForm.action = this.getUrl({
+        endpoint: postFormConfig.endpoint,
+        url: postFormConfig.url,
+      });
       hiddenForm.method = 'POST';
-      hiddenForm.target = target;
+      hiddenForm.target = postFormConfig.target ?? '_blank';
       const payloadWithToken: Record<string, any> = {
-        ...payload,
+        ...postFormConfig.payload,
         csrf_token: this.csrfToken!,
       };
 
@@ -259,7 +259,7 @@ export default class SupersetClientClass {
 
   getUrl({
     host: inputHost,
-    endpoint = '',
+    endpoint,
     url,
   }: {
     endpoint?: string;

--- a/superset-frontend/packages/superset-ui-core/src/connection/types.ts
+++ b/superset-frontend/packages/superset-ui-core/src/connection/types.ts
@@ -117,6 +117,23 @@ export interface RequestWithUrl extends RequestBase {
 // this make sure at least one of `url` or `endpoint` is set
 export type RequestConfig = RequestWithEndpoint | RequestWithUrl;
 
+export interface PostFormBase {
+  payload: Record<string, any>;
+  target?: string;
+}
+
+export interface PostFormWithEndpoint extends PostFormBase {
+  endpoint: Endpoint;
+  url?: Url;
+}
+
+export interface PostFormWithUrl extends PostFormBase {
+  url: Url;
+  endpoint?: Endpoint;
+}
+
+export type PostFormConfig = PostFormWithEndpoint | PostFormWithUrl;
+
 export interface JsonResponse {
   response: Response;
   json: JsonObject;

--- a/superset-frontend/packages/superset-ui-core/test/connection/SupersetClientClass.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/connection/SupersetClientClass.test.ts
@@ -666,7 +666,7 @@ describe('SupersetClientClass', () => {
           authSpy = jest.spyOn(SupersetClientClass.prototype, 'ensureAuth');
           await client.init();
         }
-        await client.postForm({ endpoint: mockPostFormEndpoint, payload: {}});
+        await client.postForm({ endpoint: mockPostFormEndpoint, payload: {} });
 
         const hiddenForm = createElement.mock.results[0].value;
         const csrfTokenInput = createElement.mock.results[1].value;
@@ -693,7 +693,7 @@ describe('SupersetClientClass', () => {
       client = new SupersetClientClass({ protocol, host, guestToken });
       await client.init();
 
-      await client.postForm({ endpoint: mockPostFormUrl, payload: {}});
+      await client.postForm({ endpoint: mockPostFormUrl, payload: {} });
 
       const guestTokenInput = createElement.mock.results[2].value;
 
@@ -709,7 +709,10 @@ describe('SupersetClientClass', () => {
     });
 
     it('makes postForm request with payload', async () => {
-      await client.postForm({ url: mockPostFormUrl, payload: { form_data: postFormPayload }});
+      await client.postForm({
+        url: mockPostFormUrl,
+        payload: { form_data: postFormPayload },
+      });
 
       const postFormPayloadInput = createElement.mock.results[1].value;
 
@@ -726,7 +729,7 @@ describe('SupersetClientClass', () => {
     });
 
     it('should do nothing when url is empty string', async () => {
-      const result = await client.postForm({url: '', payload: {}});
+      const result = await client.postForm({ url: '', payload: {} });
       expect(result).toBeUndefined();
       expect(createElement.mock.calls).toHaveLength(0);
       expect(appendChild.mock.calls).toHaveLength(0);

--- a/superset-frontend/packages/superset-ui-core/test/connection/SupersetClientClass.test.ts
+++ b/superset-frontend/packages/superset-ui-core/test/connection/SupersetClientClass.test.ts
@@ -666,7 +666,7 @@ describe('SupersetClientClass', () => {
           authSpy = jest.spyOn(SupersetClientClass.prototype, 'ensureAuth');
           await client.init();
         }
-        await client.postForm(mockPostFormEndpoint, {});
+        await client.postForm({ endpoint: mockPostFormEndpoint, payload: {}});
 
         const hiddenForm = createElement.mock.results[0].value;
         const csrfTokenInput = createElement.mock.results[1].value;
@@ -693,7 +693,7 @@ describe('SupersetClientClass', () => {
       client = new SupersetClientClass({ protocol, host, guestToken });
       await client.init();
 
-      await client.postForm(mockPostFormUrl, {});
+      await client.postForm({ endpoint: mockPostFormUrl, payload: {}});
 
       const guestTokenInput = createElement.mock.results[2].value;
 
@@ -709,7 +709,7 @@ describe('SupersetClientClass', () => {
     });
 
     it('makes postForm request with payload', async () => {
-      await client.postForm(mockPostFormUrl, { form_data: postFormPayload });
+      await client.postForm({ url: mockPostFormUrl, payload: { form_data: postFormPayload }});
 
       const postFormPayloadInput = createElement.mock.results[1].value;
 
@@ -726,7 +726,7 @@ describe('SupersetClientClass', () => {
     });
 
     it('should do nothing when url is empty string', async () => {
-      const result = await client.postForm('', {});
+      const result = await client.postForm({url: '', payload: {}});
       expect(result).toBeUndefined();
       expect(createElement.mock.calls).toHaveLength(0);
       expect(appendChild.mock.calls).toHaveLength(0);

--- a/superset-frontend/src/SqlLab/components/ExploreCtasResultsButton/ExploreCtasResultsButton.test.tsx
+++ b/superset-frontend/src/SqlLab/components/ExploreCtasResultsButton/ExploreCtasResultsButton.test.tsx
@@ -68,9 +68,11 @@ describe('ExploreCtasResultsButton', () => {
 
     await waitFor(() => {
       expect(postFormSpy).toHaveBeenCalledTimes(1);
-      expect(postFormSpy).toHaveBeenCalledWith('http://localhost/explore/', {
-        form_data:
-          '{"datasource":"1234__table","metrics":["count"],"groupby":[],"viz_type":"table","since":"100 years ago","all_columns":[],"row_limit":1000}',
+      expect(postFormSpy).toHaveBeenCalledWith({
+        url: 'http://localhost/explore/', payload: {
+          form_data:
+            '{"datasource":"1234__table","metrics":["count"],"groupby":[],"viz_type":"table","since":"100 years ago","all_columns":[],"row_limit":1000}',
+        }
       });
     });
   });

--- a/superset-frontend/src/SqlLab/components/ExploreCtasResultsButton/ExploreCtasResultsButton.test.tsx
+++ b/superset-frontend/src/SqlLab/components/ExploreCtasResultsButton/ExploreCtasResultsButton.test.tsx
@@ -69,10 +69,11 @@ describe('ExploreCtasResultsButton', () => {
     await waitFor(() => {
       expect(postFormSpy).toHaveBeenCalledTimes(1);
       expect(postFormSpy).toHaveBeenCalledWith({
-        url: 'http://localhost/explore/', payload: {
+        url: 'http://localhost/explore/',
+        payload: {
           form_data:
             '{"datasource":"1234__table","metrics":["count"],"groupby":[],"viz_type":"table","since":"100 years ago","all_columns":[],"row_limit":1000}',
-        }
+        },
       });
     });
   });

--- a/superset-frontend/src/components/Chart/chartAction.js
+++ b/superset-frontend/src/components/Chart/chartAction.js
@@ -41,7 +41,6 @@ import { Logger, LOG_ACTIONS_LOAD_CHART } from 'src/logger/LogUtils';
 import { allowCrossDomain as domainShardingEnabled } from 'src/utils/hostNamesConfig';
 import { updateDataMask } from 'src/dataMask/actions';
 import { waitForAsyncData } from 'src/middleware/asyncEvent';
-import { ensureAppRoot } from 'src/utils/pathUtils';
 import { safeStringify } from 'src/utils/safeStringify';
 import { extendedDayjs } from '@superset-ui/core/utils/dates';
 

--- a/superset-frontend/src/components/Chart/chartAction.js
+++ b/superset-frontend/src/components/Chart/chartAction.js
@@ -574,8 +574,11 @@ export function redirectSQLLab(formData, history) {
             },
           });
         } else {
-          SupersetClient.postForm(ensureAppRoot(redirectUrl), {
-            form_data: safeStringify(payload),
+          SupersetClient.postForm({
+            endpoint: redirectUrl,
+            payload: {
+              form_data: safeStringify(payload),
+            },
           });
         }
       })

--- a/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
+++ b/superset-frontend/src/explore/components/controls/DatasourceControl/index.jsx
@@ -261,8 +261,11 @@ class DatasourceControl extends PureComponent {
             datasourceKey: `${datasource.id}__${datasource.type}`,
             sql: datasource.sql,
           };
-          SupersetClient.postForm('/sqllab/', {
-            form_data: safeStringify(payload),
+          SupersetClient.postForm({
+            endpoint: '/sqllab/',
+            payload: {
+              form_data: safeStringify(payload),
+            },
           });
         }
         break;

--- a/superset-frontend/src/explore/components/controls/ViewQueryModalFooter.tsx
+++ b/superset-frontend/src/explore/components/controls/ViewQueryModalFooter.tsx
@@ -55,7 +55,7 @@ const ViewQueryModalFooter: FC<ViewQueryModalFooterProps> = (props: {
       sql,
     };
     if (openInNewWindow) {
-      SupersetClient.postForm('/sqllab/', payload);
+      SupersetClient.postForm({ endpoint: '/sqllab/', payload });
     } else {
       history.push({
         pathname: '/sqllab',

--- a/superset-frontend/src/explore/exploreUtils/index.js
+++ b/superset-frontend/src/explore/exploreUtils/index.js
@@ -277,8 +277,8 @@ export const exportChart = async ({
   }
 
   SupersetClient.postForm({
-    endpoint: endpoint,
-    url: url,
+    endpoint,
+    url,
     payload: { form_data: safeStringify(payload) },
   });
 };

--- a/superset-frontend/src/explore/exploreUtils/index.js
+++ b/superset-frontend/src/explore/exploreUtils/index.js
@@ -252,6 +252,7 @@ export const exportChart = async ({
   force = false,
   ownState = {},
 }) => {
+  let endpoint;
   let url;
   let payload;
   const [useLegacyApi, parseMethod] = getQuerySettings(formData);
@@ -264,7 +265,7 @@ export const exportChart = async ({
     });
     payload = formData;
   } else {
-    url = ensureAppRoot('/api/v1/chart/data');
+    endpoint = '/api/v1/chart/data';
     payload = await buildV1ChartDataPayload({
       formData,
       force,
@@ -275,7 +276,11 @@ export const exportChart = async ({
     });
   }
 
-  SupersetClient.postForm(url, { form_data: safeStringify(payload) });
+  SupersetClient.postForm({
+    endpoint: endpoint,
+    url: url,
+    payload: { form_data: safeStringify(payload) },
+  });
 };
 
 export const exploreChart = (formData, requestParams) => {
@@ -285,7 +290,10 @@ export const exploreChart = (formData, requestParams) => {
     allowDomainSharding: false,
     requestParams,
   });
-  SupersetClient.postForm(url, { form_data: safeStringify(formData) });
+  SupersetClient.postForm({
+    url: url,
+    payload: { form_data: safeStringify(formData) },
+  });
 };
 
 export const useDebouncedEffect = (effect, delay, deps) => {

--- a/superset-frontend/src/explore/exploreUtils/index.js
+++ b/superset-frontend/src/explore/exploreUtils/index.js
@@ -291,7 +291,7 @@ export const exploreChart = (formData, requestParams) => {
     requestParams,
   });
   SupersetClient.postForm({
-    url: url,
+    url,
     payload: { form_data: safeStringify(formData) },
   });
 };

--- a/superset-frontend/src/pages/Login/Login.test.tsx
+++ b/superset-frontend/src/pages/Login/Login.test.tsx
@@ -29,7 +29,7 @@ const defaultBootstrapData = (authUserRegistration: boolean = false) => ({
       AUTH_PROVIDERS: [],
       AUTH_USER_REGISTRATION: authUserRegistration,
     },
-    feature_flags: {}
+    feature_flags: {},
   },
 });
 
@@ -39,12 +39,10 @@ jest.mock('src/utils/getBootstrapData', () => ({
   applicationRoot: jest.fn(() => ''),
 }));
 
-const mockGetBootstrapData = (getBootstrapData as jest.Mock);
-const mockApplicationRoot = (applicationRoot as jest.Mock);
+const mockGetBootstrapData = getBootstrapData as jest.Mock;
+const mockApplicationRoot = applicationRoot as jest.Mock;
 
-const renderLogin = () =>
-  render(<Login />, { useRedux: true });
-
+const renderLogin = () => render(<Login />, { useRedux: true });
 
 test('should render login form elements', () => {
   renderLogin();
@@ -78,68 +76,78 @@ test('should render registration button with correct app root URL when authRegis
   expect(registerButton).toHaveAttribute('href', '/superset/register/');
 });
 
-test.each([['', '/superset']])('should render OAuth providers with app root %s', (app_root: string) => {
-  mockGetBootstrapData.mockReturnValue({
-    common: {
-      conf: {
-        AUTH_TYPE: 4, // AuthType.AuthOauth
-        AUTH_PROVIDERS: [
-          { name: 'google', icon: 'google' },
-          { name: 'github', icon: 'github' },
-        ],
-        AUTH_USER_REGISTRATION: false,
+test.each([['', '/superset']])(
+  'should render OAuth providers with app root %s',
+  (app_root: string) => {
+    mockGetBootstrapData.mockReturnValue({
+      common: {
+        conf: {
+          AUTH_TYPE: 4, // AuthType.AuthOauth
+          AUTH_PROVIDERS: [
+            { name: 'google', icon: 'google' },
+            { name: 'github', icon: 'github' },
+          ],
+          AUTH_USER_REGISTRATION: false,
+        },
       },
-    },
-  });
+    });
 
-  mockApplicationRoot.mockReturnValue(app_root);
+    mockApplicationRoot.mockReturnValue(app_root);
 
-  renderLogin();
+    renderLogin();
 
-  const googleButton = screen.getByRole('link', {
-    name: /Sign in with Google/i,
-  });
-  const githubButton = screen.getByRole('link', {
-    name: /Sign in with Github/i,
-  });
+    const googleButton = screen.getByRole('link', {
+      name: /Sign in with Google/i,
+    });
+    const githubButton = screen.getByRole('link', {
+      name: /Sign in with Github/i,
+    });
 
-  expect(googleButton).toHaveAttribute('href', `${app_root}/login/google`);
-  expect(githubButton).toHaveAttribute('href', `${app_root}/login/github`);
-});
+    expect(googleButton).toHaveAttribute('href', `${app_root}/login/google`);
+    expect(githubButton).toHaveAttribute('href', `${app_root}/login/github`);
+  },
+);
 
-test.each([[1, 2]])('should call SupersetClient.postForm with correct endpoint for AuthDB/AuthLDAP', async (authType: number) => {
-  mockGetBootstrapData.mockReturnValue({
-    common: {
-      conf: {
-        AUTH_TYPE: authType,
-        AUTH_PROVIDERS: [],
-        AUTH_USER_REGISTRATION: false,
+test.each([[1, 2]])(
+  'should call SupersetClient.postForm with correct endpoint for AuthDB/AuthLDAP',
+  async (authType: number) => {
+    mockGetBootstrapData.mockReturnValue({
+      common: {
+        conf: {
+          AUTH_TYPE: authType,
+          AUTH_PROVIDERS: [],
+          AUTH_USER_REGISTRATION: false,
+        },
       },
-    },
-  });
-  mockApplicationRoot.mockReturnValue('/superset');
+    });
+    mockApplicationRoot.mockReturnValue('/superset');
 
-  const postFormSpy = jest
-    .spyOn(SupersetClient, 'postForm')
-    .mockResolvedValue();
+    const postFormSpy = jest
+      .spyOn(SupersetClient, 'postForm')
+      .mockResolvedValue();
 
-  renderLogin();
+    renderLogin();
 
-  // Fill in the form
-  const usernameInput = screen.getByTestId('username-input');
-  const passwordInput = screen.getByTestId('password-input');
-  const loginButton = screen.getByTestId('login-button');
+    // Fill in the form
+    const usernameInput = screen.getByTestId('username-input');
+    const passwordInput = screen.getByTestId('password-input');
+    const loginButton = screen.getByTestId('login-button');
 
-  await userEvent.type(usernameInput, 'testuser');
-  await userEvent.type(passwordInput, 'testpass');
-  await userEvent.click(loginButton);
+    await userEvent.type(usernameInput, 'testuser');
+    await userEvent.type(passwordInput, 'testpass');
+    await userEvent.click(loginButton);
 
-  await waitFor(() => {
-    expect(postFormSpy).toHaveBeenCalledWith(
-      // Should be bare endpoint, not /superset/login/
-      { endpoint: '/login/', payload: { username: 'testuser', password: 'testpass' }, target: '' },
-    );
-  });
+    await waitFor(() => {
+      expect(postFormSpy).toHaveBeenCalledWith(
+        // Should be bare endpoint, not /superset/login/
+        {
+          endpoint: '/login/',
+          payload: { username: 'testuser', password: 'testpass' },
+          target: '',
+        },
+      );
+    });
 
-  postFormSpy.mockRestore();
-});
+    postFormSpy.mockRestore();
+  },
+);

--- a/superset-frontend/src/pages/Login/Login.test.tsx
+++ b/superset-frontend/src/pages/Login/Login.test.tsx
@@ -16,24 +16,39 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import { render, screen } from 'spec/helpers/testing-library';
+import { render, screen, waitFor } from 'spec/helpers/testing-library';
+import userEvent from '@testing-library/user-event';
+import { SupersetClient } from '@superset-ui/core';
+import getBootstrapData, { applicationRoot } from 'src/utils/getBootstrapData';
 import Login from './index';
+import { AuthType } from 'src/features/databases/DatabaseModal';
+
+const defaultBootstrapData = (authUserRegistration: boolean = false) => ({
+  common: {
+    conf: {
+      AUTH_TYPE: 1,
+      AUTH_PROVIDERS: [],
+      AUTH_USER_REGISTRATION: authUserRegistration,
+    },
+    feature_flags: {}
+  },
+});
 
 jest.mock('src/utils/getBootstrapData', () => ({
   __esModule: true,
-  default: () => ({
-    common: {
-      conf: {
-        AUTH_TYPE: 1,
-        AUTH_PROVIDERS: [],
-        AUTH_USER_REGISTRATION: false,
-      },
-    },
-  }),
+  default: jest.fn(() => defaultBootstrapData()),
+  applicationRoot: jest.fn(() => ''),
 }));
 
+const mockGetBootstrapData = (getBootstrapData as jest.Mock);
+const mockApplicationRoot = (applicationRoot as jest.Mock);
+
+const renderLogin = () =>
+  render(<Login />, { useRedux: true });
+
+
 test('should render login form elements', () => {
-  render(<Login />);
+  renderLogin();
   expect(screen.getByTestId('login-form')).toBeInTheDocument();
   expect(screen.getByTestId('username-input')).toBeInTheDocument();
   expect(screen.getByTestId('password-input')).toBeInTheDocument();
@@ -42,14 +57,90 @@ test('should render login form elements', () => {
 });
 
 test('should render username and password labels', () => {
-  render(<Login />);
+  renderLogin();
   expect(screen.getByText('Username:')).toBeInTheDocument();
   expect(screen.getByText('Password:')).toBeInTheDocument();
 });
 
 test('should render form instruction text', () => {
-  render(<Login />);
+  renderLogin();
   expect(
     screen.getByText('Enter your login and password below:'),
   ).toBeInTheDocument();
+});
+
+test('should render registration button with correct app root URL when authRegister=true', () => {
+  mockGetBootstrapData.mockReturnValue(defaultBootstrapData(true));
+  mockApplicationRoot.mockReturnValue('/superset');
+
+  renderLogin();
+
+  const registerButton = screen.getByTestId('register-button');
+  expect(registerButton).toHaveAttribute('href', '/superset/register/');
+});
+
+test.each([['', '/superset']])('should render OAuth providers with app root %s', (app_root: string) => {
+  mockGetBootstrapData.mockReturnValue({
+    common: {
+      conf: {
+        AUTH_TYPE: 4, // AuthType.AuthOauth
+        AUTH_PROVIDERS: [
+          { name: 'google', icon: 'google' },
+          { name: 'github', icon: 'github' },
+        ],
+        AUTH_USER_REGISTRATION: false,
+      },
+    },
+  });
+
+  mockApplicationRoot.mockReturnValue(app_root);
+
+  renderLogin();
+
+  const googleButton = screen.getByRole('link', {
+    name: /Sign in with Google/i,
+  });
+  const githubButton = screen.getByRole('link', {
+    name: /Sign in with Github/i,
+  });
+
+  expect(googleButton).toHaveAttribute('href', `${app_root}/login/google`);
+  expect(githubButton).toHaveAttribute('href', `${app_root}/login/github`);
+});
+
+test.each([[1, 2]])('should call SupersetClient.postForm with correct endpoint for AuthDB/AuthLDAP', async (authType: number) => {
+  mockGetBootstrapData.mockReturnValue({
+    common: {
+      conf: {
+        AUTH_TYPE: authType,
+        AUTH_PROVIDERS: [],
+        AUTH_USER_REGISTRATION: false,
+      },
+    },
+  });
+  mockApplicationRoot.mockReturnValue('/superset');
+
+  const postFormSpy = jest
+    .spyOn(SupersetClient, 'postForm')
+    .mockResolvedValue();
+
+  renderLogin();
+
+  // Fill in the form
+  const usernameInput = screen.getByTestId('username-input');
+  const passwordInput = screen.getByTestId('password-input');
+  const loginButton = screen.getByTestId('login-button');
+
+  await userEvent.type(usernameInput, 'testuser');
+  await userEvent.type(passwordInput, 'testpass');
+  await userEvent.click(loginButton);
+
+  await waitFor(() => {
+    expect(postFormSpy).toHaveBeenCalledWith(
+      // Should be bare endpoint, not /superset/login/
+      { endpoint: '/login/', payload: { username: 'testuser', password: 'testpass' }, target: '' },
+    );
+  });
+
+  postFormSpy.mockRestore();
 });

--- a/superset-frontend/src/pages/Login/Login.test.tsx
+++ b/superset-frontend/src/pages/Login/Login.test.tsx
@@ -21,7 +21,6 @@ import userEvent from '@testing-library/user-event';
 import { SupersetClient } from '@superset-ui/core';
 import getBootstrapData, { applicationRoot } from 'src/utils/getBootstrapData';
 import Login from './index';
-import { AuthType } from 'src/features/databases/DatabaseModal';
 
 const defaultBootstrapData = (authUserRegistration: boolean = false) => ({
   common: {

--- a/superset-frontend/src/pages/Login/index.tsx
+++ b/superset-frontend/src/pages/Login/index.tsx
@@ -237,7 +237,7 @@ export default function Login() {
                     <Button
                       block
                       type="default"
-                      href={ensureAppRoot("/register/")}
+                      href={ensureAppRoot('/register/')}
                       data-test="register-button"
                     >
                       {t('Register')}

--- a/superset-frontend/src/pages/Login/index.tsx
+++ b/superset-frontend/src/pages/Login/index.tsx
@@ -30,6 +30,7 @@ import {
 import { useState, useMemo } from 'react';
 import { capitalize } from 'lodash/fp';
 import getBootstrapData from 'src/utils/getBootstrapData';
+import { ensureAppRoot } from 'src/utils/pathUtils';
 
 type OAuthProvider = {
   name: string;
@@ -94,7 +95,7 @@ export default function Login() {
   );
 
   const buildProviderLoginUrl = (providerName: string) => {
-    const base = `/login/${providerName}`;
+    const base = ensureAppRoot(`/login/${providerName}`);
     return nextUrl
       ? `${base}${base.includes('?') ? '&' : '?'}next=${encodeURIComponent(nextUrl)}`
       : base;
@@ -107,7 +108,11 @@ export default function Login() {
 
   const onFinish = (values: LoginForm) => {
     setLoading(true);
-    SupersetClient.postForm(loginEndpoint, values, '').finally(() => {
+    SupersetClient.postForm({
+      endpoint: loginEndpoint,
+      payload: values,
+      target: '',
+    }).finally(() => {
       setLoading(false);
     });
   };
@@ -232,7 +237,7 @@ export default function Login() {
                     <Button
                       block
                       type="default"
-                      href="/register/"
+                      href=ensureAppRoot("/register/")
                       data-test="register-button"
                     >
                       {t('Register')}

--- a/superset-frontend/src/pages/Login/index.tsx
+++ b/superset-frontend/src/pages/Login/index.tsx
@@ -237,7 +237,7 @@ export default function Login() {
                     <Button
                       block
                       type="default"
-                      href=ensureAppRoot("/register/")
+                      href={ensureAppRoot("/register/")}
                       data-test="register-button"
                     >
                       {t('Register')}

--- a/superset-frontend/src/pages/Register/Register.test.tsx
+++ b/superset-frontend/src/pages/Register/Register.test.tsx
@@ -17,8 +17,9 @@
  * under the License.
  */
 import { render, screen } from 'spec/helpers/testing-library';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, Route } from 'react-router-dom';
 import Register from './index';
+import { applicationRoot } from 'src/utils/getBootstrapData';
 
 jest.mock('src/utils/getBootstrapData', () => ({
   __esModule: true,
@@ -29,6 +30,7 @@ jest.mock('src/utils/getBootstrapData', () => ({
       },
     },
   }),
+  applicationRoot: jest.fn(() => '')
 }));
 
 jest.mock('react-google-recaptcha', () => ({
@@ -40,6 +42,13 @@ const renderRegister = () =>
   render(
     <MemoryRouter>
       <Register />
+    </MemoryRouter>,
+  );
+
+const renderActivated = () =>
+  render(
+    <MemoryRouter initialEntries={['/abcdefgh']}>
+      <Route path="/:activationHash" component={Register} />
     </MemoryRouter>,
   );
 
@@ -79,4 +88,19 @@ test('should render input placeholders', () => {
   expect(screen.getByPlaceholderText('Email')).toBeInTheDocument();
   expect(screen.getByPlaceholderText('Password')).toBeInTheDocument();
   expect(screen.getByPlaceholderText('Confirm password')).toBeInTheDocument();
+});
+
+test('should render login button with login URL when no app root', () => {
+  renderActivated();
+
+  const loginButton = screen.getByTestId('login-button');
+  expect(loginButton).toHaveAttribute('href', '/login/');
+});
+
+test('should render login button with login URL app root set', () => {
+  (applicationRoot as jest.Mock).mockReturnValue('/superset');
+  renderActivated();
+
+  const loginButton = screen.getByTestId('login-button');
+  expect(loginButton).toHaveAttribute('href', '/superset/login/');
 });

--- a/superset-frontend/src/pages/Register/Register.test.tsx
+++ b/superset-frontend/src/pages/Register/Register.test.tsx
@@ -18,8 +18,8 @@
  */
 import { render, screen } from 'spec/helpers/testing-library';
 import { MemoryRouter, Route } from 'react-router-dom';
-import Register from './index';
 import { applicationRoot } from 'src/utils/getBootstrapData';
+import Register from './index';
 
 jest.mock('src/utils/getBootstrapData', () => ({
   __esModule: true,

--- a/superset-frontend/src/pages/Register/Register.test.tsx
+++ b/superset-frontend/src/pages/Register/Register.test.tsx
@@ -30,7 +30,7 @@ jest.mock('src/utils/getBootstrapData', () => ({
       },
     },
   }),
-  applicationRoot: jest.fn(() => '')
+  applicationRoot: jest.fn(() => ''),
 }));
 
 jest.mock('react-google-recaptcha', () => ({

--- a/superset-frontend/src/pages/Register/index.tsx
+++ b/superset-frontend/src/pages/Register/index.tsx
@@ -107,7 +107,11 @@ export default function Login() {
       conf_password: values.confirmPassword,
       'g-recaptcha-response': captchaResponse,
     };
-    SupersetClient.postForm('/register/form', payload, '').finally(() => {
+    SupersetClient.postForm({
+      endpoint: '/register/form',
+      payload,
+      target: '',
+    }).finally(() => {
       setLoading(false);
     });
   };

--- a/superset-frontend/src/pages/Register/index.tsx
+++ b/superset-frontend/src/pages/Register/index.tsx
@@ -88,7 +88,11 @@ export default function Login() {
           title="Registration successful"
           subTitle="Your account is activated. You can log in with your credentials."
           extra={[
-            <Button type="default" href={ensureAppRoot("/login/")} data-test="login-button">
+            <Button
+              type="default"
+              href={ensureAppRoot('/login/')}
+              data-test="login-button"
+            >
               {t('Login')}
             </Button>,
           ]}

--- a/superset-frontend/src/pages/Register/index.tsx
+++ b/superset-frontend/src/pages/Register/index.tsx
@@ -28,6 +28,7 @@ import {
 } from '@superset-ui/core/components';
 import { useState } from 'react';
 import getBootstrapData from 'src/utils/getBootstrapData';
+import { ensureAppRoot } from 'src/utils/pathUtils';
 import ReactCAPTCHA from 'react-google-recaptcha';
 import { useParams } from 'react-router-dom';
 
@@ -87,7 +88,7 @@ export default function Login() {
           title="Registration successful"
           subTitle="Your account is activated. You can log in with your credentials."
           extra={[
-            <Button type="default" href="/login/" data-test="login-button">
+            <Button type="default" href={ensureAppRoot("/login/")} data-test="login-button">
               {t('Login')}
             </Button>,
           ]}

--- a/superset/views/utils.py
+++ b/superset/views/utils.py
@@ -75,9 +75,9 @@ def redirect_to_login(next_target: str | None = None) -> FlaskResponse:
     target = next_target
     if target is None and has_request_context():
         if request.query_string:
-            target = request.full_path.rstrip("?")
+            target = request.script_root + request.full_path.rstrip("?")
         else:
-            target = request.path
+            target = request.script_root + request.path
 
     if target:
         query["next"] = [target]


### PR DESCRIPTION
The SupersetClient.postForm api is inconsistent with the rest of the class as it does not accept an `url` parameter. This introduces a proper type for the arguments and allows endpoint or url. Call sites have been updated.

Other fixes include Login page fixes found when fixing postForm calls. Tests for Login and Register pages have been added.